### PR TITLE
Initial implementation.

### DIFF
--- a/.jscsrc
+++ b/.jscsrc
@@ -6,6 +6,7 @@
      "catch"
   ],
   "disallowSpacesInsideObjectBrackets": null,
+  "disallowMultipleVarDecl": "exceptUndefined",
   "requireSpaceAfterLineComment": true,
   "maximumLineLength": {
      "value": 80,

--- a/README.md
+++ b/README.md
@@ -7,3 +7,75 @@ An Express middleware for collecting HTTP statistics.
 ```
 $ npm install strong-express-metrics
 ```
+
+## Usage
+
+```js
+var express = require('express');
+var metrics = require('strong-express-metrics');
+
+var app = express();
+app.use(metrics());
+app.listen(3000);
+```
+
+You can extend the metrics reported by the middleware by providing
+a builder function. The output of this builder function will be merged
+with the default record produced by the middleware.
+
+```js
+app.use(metrics(function buildRecord(req, res) {
+  return {
+    client: {
+      id: req.authInfo.app.id,
+      username: req.authInfo.user.email
+    },
+    data: {
+      // put your custom metrics here
+    }
+  };
+}));
+```
+
+If your application is not running inside StrongLoop's Supervisor,
+you can provide a custom function to process and report the statistics.
+
+```js
+metrics.onRecord(function(data) {
+  // simple statsd output
+  console.log('url:%s|1|c', data.request.url);
+  console.log('status:%s|1|c', data.response.status);
+  console.log('response-time|%s|ms', data.duration);
+});
+```
+
+## Record format
+
+The middleware produces records in the following format.
+
+```js
+{
+  timestamp: Date.now(),
+  client: {
+    address: req.socket.address().address,
+    id: undefined, // builder should override
+    username: undefined // builder should override
+  },
+  request: {
+    method: req.method,
+    url: req.url
+  },
+  response: {
+    status: res.statusCode,
+    duration: res.durationInMs,
+    bytes: undefined // TODO
+  },
+  process: {
+    pid: process.pid,
+    workerId: cluster.worker && cluster.workerId
+  },
+  data: {
+    // placeholder for user-provided data
+  }
+}
+```

--- a/docs.json
+++ b/docs.json
@@ -1,0 +1,6 @@
+{
+  "title": "strong-express-metrics",
+  "content": [
+    "index.js"
+  ]
+}

--- a/index.js
+++ b/index.js
@@ -1,0 +1,95 @@
+var cluster = require('cluster');
+var extend = require('util')._extend;
+
+/**
+ * Create a middleware handler for collecting statistics.
+ *
+ * @callback {function} recordBuilder The builder function is called
+ *   for each request, the return value is collected as a stats record.
+ * @param {Request} req The express request object.
+ * @param {Response} res The express response object.
+ * @return {Object} A key/value map describing a stats record.
+ * @end
+ *
+ * @header metrics(recordBuilder)
+ */
+module.exports = createStatsHandler;
+
+/**
+ * Register an observer function to be notified whenever a new stats record
+ * is collected.
+ * @callback {function} observer The observer function.
+ * @param {Object} data The data returned by the record builder function.
+ * @end
+ *
+ * @header metrics.onRecord(observer)
+ */
+module.exports.onRecord = onRecord;
+
+function createStatsHandler(recordBuilder) {
+  return function statistics(req, res, next) {
+    var start = new Date();
+    res.on('finish', function() {
+      res.durationInMs = new Date() - start;
+      try {
+        var record = createRecord(recordBuilder, req, res);
+        notifyObservers(record);
+      } catch (err) {
+        console.warn('strong-express-metrics ignored error', err);
+      }
+    });
+    next();
+  };
+}
+
+function createRecord(builder, req, res) {
+  var record = {
+    timestamp: Date.now(),
+    client: {
+      address: req.socket.address().address,
+      // NOTE(bajtos) How to extract client-id and username?
+      // Should we parse Authorization header for Basic Auth?
+      id: undefined,
+      username: undefined
+    },
+    request: {
+      method: req.method,
+      url: req.url
+    },
+    response: {
+      status: res.statusCode,
+      duration: res.durationInMs,
+      // Computing the length of a writable stream
+      // is tricky and expensive.
+      bytes: undefined
+    },
+    process: {
+      pid: process.pid,
+      workerId: cluster.worker && cluster.workerId
+    },
+    data: {
+      // placeholder for user-provided data
+    }
+  };
+
+  var custom = builder && builder(req, res);
+
+  if (custom) {
+    for (var k in custom)
+      record[k] = extend(record[k], custom[k]);
+  }
+
+  return record;
+}
+
+var observers = [];
+
+function onRecord(observer) {
+  observers.push(observer);
+}
+
+function notifyObservers(data) {
+  for (var i = 0; i < observers.length; i++) {
+    observers[i](data);
+  }
+}

--- a/index.js
+++ b/index.js
@@ -31,6 +31,10 @@ function createStatsHandler(recordBuilder) {
     var start = new Date();
     res.on('finish', function() {
       res.durationInMs = new Date() - start;
+
+      // Performance optimization: skip when there are no observers
+      if (observers.length < 1) return;
+
       try {
         var record = createRecord(recordBuilder, req, res);
         notifyObservers(record);

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
   },
   "devDependencies": {
     "chai": "^1.10.0",
+    "express": "^4.11.1",
     "jscs": "^1.10.0",
     "jshint": "^2.6.0",
     "mocha": "^2.1.0",

--- a/test/metrics.test.js
+++ b/test/metrics.test.js
@@ -1,0 +1,173 @@
+var express = require('express');
+var http = require('http');
+var xstats = require('../');
+var supertest = require('supertest');
+var expect = require('chai').expect;
+
+var onRecord;
+xstats.onRecord(function(data) {
+  return onRecord && onRecord(data);
+});
+
+describe('xstats', function() {
+  var app, server, request, records;
+  beforeEach(function setup(done) {
+    records = null;
+    onRecord = function(data) {
+      if (records === null)
+        records = data;
+      else
+        records = [records, data];
+    };
+
+    app = express();
+    server = http.createServer(app);
+    request = supertest(server);
+    // Explicitly listen on an IPv4 address '127.0.0.1'
+    // Otherwise an IPv6 address may be reported by the server
+    server.listen(0, '127.0.0.1', done);
+  });
+
+  afterEach(function stopServer(done) {
+    server.close(done);
+  });
+
+  it('calls onRecord when the response is finished', function(done) {
+    app.use(xstats(function(req, res) {
+      return {
+        data: {
+          url: req.url,
+          status: res.statusCode
+        }
+      };
+    }));
+
+    request.get('/does-not-exist')
+      .expect(404, function(err, res) {
+        if (err) return done(err);
+        expect(getProp(records, 'data'))
+          .to.eql({ url: '/does-not-exist', status: 404 });
+        done();
+      });
+  });
+
+  it('provides duration via `res.duration`', function(done) {
+    app.use(xstats(function(req, res) {
+      return { data: { duration: res.durationInMs } };
+    }));
+
+    request.get('/').end(function(err, res) {
+      if (err) return done(err);
+      expect(getProp(records, 'data'))
+        .to.have.property('duration').to.be.a('number');
+      done();
+    });
+  });
+
+  it('handles no builder function', function(done) {
+    app.use(xstats());
+    request.get('/').end(function(err, res) {
+      if (err) return done(err);
+      expect(getProp(records, 'data')).to.eql({});
+      done();
+    });
+  });
+
+  it('adds `process` data', function(done) {
+    app.use(xstats());
+    request.get('/').end(function(err, res) {
+      if (err) return done(err);
+      var proc = getProp(records, 'process');
+      expect(proc).to.have.property('pid', process.pid);
+      expect(proc).to.include.key('workerId');
+      done();
+    });
+  });
+
+  it('adds `timestamp` property', function(done) {
+    app.use(xstats());
+    request.get('/').end(function(err, res) {
+      if (err) return done(err);
+      var now = Date.now();
+      expect(records).to.have.property('timestamp').within(now - 300, now);
+      done();
+    });
+  });
+
+  it('adds properties with Common Log data', function(done) {
+    app.use(xstats());
+    app.get('/bytes', function(req, res) {
+      res.send('hello');
+    });
+    request.get('/bytes?with=query').end(function(err) {
+      if (err) return done(err);
+      expect(getProp(records, 'client')).to.eql({
+        address: '127.0.0.1',
+        id: undefined,
+        username: undefined
+      });
+
+      expect(getProp(records, 'request')).to.eql({
+        method: 'GET',
+        url: '/bytes?with=query'
+      });
+
+      var res = getProp(records, 'response');
+      expect(res).to.have.property('status', 200);
+      expect(res).to.have.property('duration').a('number').within(0, 100);
+      expect(res).to.include.key('bytes');
+      done();
+    });
+  });
+
+  it('extends default data with user-provided properties', function(done) {
+    app.use(xstats(function(req, res) {
+      return { client: {
+        address: '10.20.30.40',
+        id: 'test-app',
+        username: 'test-user'
+      }};
+    }));
+    request.get('/').end(function(err, res) {
+      expect(getProp(records, 'client')).to.eql({
+        address: '10.20.30.40',
+        id: 'test-app',
+        username: 'test-user'
+      });
+      done();
+    });
+  });
+
+  it('catches errors from a record-builder function', function(done) {
+    app.use(xstats(function(req, res) {
+      throw new Error('expected test error');
+    }));
+
+    // the test passes when the process does not crash
+    // and the error is not handled by express
+    request.get('/not-found').expect(404, done);
+  });
+
+  it('catches errors from a record-observer function', function(done) {
+    onRecord = function() { throw new Error('expected test error'); };
+
+    app.use(xstats(function(req, res) { return {}; }));
+
+    // the test passes when the process does not crash
+    // and the error is not handled by express
+    request.get('/not-found').expect(404, done);
+  });
+
+  function getProp(objOrArray, name) {
+    if (Array.isArray(objOrArray))
+      return objOrArray.forEach(getter);
+    else
+      return getter(objOrArray);
+
+    function getter(obj) {
+      if (!obj || typeof obj !== 'object')
+        return '' + obj + '[' + name + ']';
+      return (name in obj) ? obj[name] : 'unknown key: ' + name;
+    }
+  }
+});


### PR DESCRIPTION
Usage (see also README):

``` js
var express = require('express');
var metrics = require('strong-express-metrics');
var app = express();

// 1. Produce the default set of metrics (Common Access Log)
app.use(metrics());

// 2. Add custom metrics
app.use(metrics(function(req, res) {
  return {
    client: {
      id: req.authInfo.app.id,
      username: req.authInfo.user.email
    },
    data: {
      // put your custom metrics here
    }
  };
});

// 3. Optionally provide a function to report the statistics.
// This step is not necessary when the app is started by 
// StrongLoop's Supervisor
metrics.onRecord(function(data) {
  // simple statsd output
  console.log('url:%s|1|c', data.request.url);
  console.log('status:%s|1|c', data.response.status);
  console.log('response-time|%s|ms', data.response.duration);
});

app.listen(3000);
```

Connect strongloop-internal/scrum-loopback#123.

This initial implementation is intentionally using a builder function. My plan is to extend the middleware factory to accept an options object (instead of builder fn) that describes how to map req/res properties to stats record and implement some sort of interpreter/compiler to convert this description into a builder function. However, that's out of scope of this PR.

/to @sam-github @rmg please review.

I am envisioning that strong-agent's probe will call `metrics.onRequest` to register an observer. Is this API good enough for that purpose?
