### PR TITLE
Add "record.version"; add "record.loopback" for LoopBack applications

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,14 @@ The middleware produces records in the following format.
   },
   data: {
     // placeholder for user-provided data
+  },
+  // extra info filled for LoopBack applications only
+  loopback: {
+    modelName: 'User',
+    remoteMethod: 'prototype.updateAttributes',
+    // instanceId is undefined for static methods
+    // e.g. User.find() or User.login()
+    instanceId: 1234
   }
 }
 ```

--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ The middleware produces records in the following format.
 
 ```js
 {
+  version: require('./package.json').version,
   timestamp: Date.now(),
   client: {
     address: req.socket.address().address,

--- a/index.js
+++ b/index.js
@@ -81,6 +81,8 @@ function createRecord(builder, req, res) {
     }
   };
 
+  addLoopBackInfo(record, req, res);
+
   var custom = builder && builder(req, res);
 
   if (custom) {
@@ -89,6 +91,25 @@ function createRecord(builder, req, res) {
   }
 
   return record;
+}
+
+function addLoopBackInfo(record, req, res) {
+  var ctx = req.remotingContext;
+  if (!ctx) return;
+
+  var method = ctx.method;
+  var lb = record.loopback = {
+    modelName: method.sharedClass ? method.sharedClass.name : null,
+    remoteMethod: method.name
+  };
+
+  if (!method.isStatic) {
+    lb.remoteMethod = 'prototype.' + lb.remoteMethod;
+    lb.instanceId = ctx.ctorArgs && ctx.ctorArgs.id;
+  } else if (/ById$/.test(method.name)) {
+    // PersistedModel.findById, PersistedModel.deleteById
+    lb.instanceId = ctx.args.id;
+  }
 }
 
 var observers = [];

--- a/index.js
+++ b/index.js
@@ -1,6 +1,8 @@
 var cluster = require('cluster');
 var extend = require('util')._extend;
 
+var VERSION = require('./package.json').version;
+
 /**
  * Create a middleware handler for collecting statistics.
  *
@@ -53,6 +55,7 @@ function createStatsHandler(recordBuilder) {
 
 function createRecord(builder, req, res) {
   var record = {
+    version: VERSION,
     timestamp: Date.now(),
     client: {
       address: req.__clientAddress,

--- a/package.json
+++ b/package.json
@@ -28,6 +28,8 @@
     "express": "^4.11.1",
     "jscs": "^1.10.0",
     "jshint": "^2.6.0",
+    "loopback": "^2.15.0",
+    "loopback-datasource-juggler": "^2.23.0",
     "mocha": "^2.1.0",
     "supertest": "^0.15.0"
   }

--- a/test/loopback.test.js
+++ b/test/loopback.test.js
@@ -1,0 +1,99 @@
+var loopback = require('loopback');
+var xstats = require('../');
+var supertest = require('supertest');
+var expect = require('chai').expect;
+
+var onRecord;
+xstats.onRecord(function(data) {
+  return onRecord && onRecord(data);
+});
+
+describe('loopback metrics', function() {
+  var app, server, request, records;
+  beforeEach(function setup(done) {
+    records = null;
+    onRecord = function(data) {
+      if (records === null)
+        records = data;
+      else
+        records = [records, data];
+    };
+
+    app = loopback();
+    app.dataSource('db', { connector: 'memory' });
+
+    var Car = loopback.createModel('Car');
+    app.model(Car, { dataSource: 'db' });
+
+    app.use(xstats());
+    app.use(loopback.rest());
+
+    // Explicitly listen on an IPv4 address '127.0.0.1'
+    // Otherwise an IPv6 address may be reported by the server
+    app.set('host', '127.0.0.1');
+    app.set('port', 0);
+    server = app.listen(function() {
+      request = supertest(app.get('url').replace(/\/$/, ''));
+      done();
+    });
+  });
+
+  afterEach(function stopServer(done) {
+    server.close(done);
+  });
+
+  it('provides model and method for static methods', function(done) {
+    request.get('/cars').end(function(err, res) {
+      if (err) return done(err);
+      expect(getProp(records, 'loopback')).to.eql({
+        modelName: 'Car',
+        remoteMethod: 'find'
+      });
+      done();
+    });
+  });
+
+  it('provides model, method and id for instance methods', function(done) {
+    request.put('/cars/1234').send({}).end(function(err, res) {
+      if (err) return done(err);
+      expect(getProp(records, 'loopback')).to.eql({
+        modelName: 'Car',
+        remoteMethod: 'prototype.updateAttributes',
+        instanceId: 1234
+      });
+      done();
+    });
+  });
+
+  it('provides instance id for PersistedModel.findById', function(done) {
+    request.get('/cars/1234').end(function(err, res) {
+      if (err) return done(err);
+      console.log('records\n', JSON.stringify(records, null, 2), '\n');
+      expect(getProp(records, 'loopback'))
+        .to.have.property('instanceId', 1234);
+      done();
+    });
+  });
+
+  it('provides instance id for PersistedModel.deleteById', function(done) {
+    request.del('/cars/1234').end(function(err, res) {
+      if (err) return done(err);
+      expect(getProp(records, 'loopback'))
+        .to.have.property('instanceId', 1234);
+      done();
+    });
+  });
+
+  function getProp(objOrArray, name) {
+    if (Array.isArray(objOrArray))
+      return objOrArray.forEach(getter);
+    else
+      return getter(objOrArray);
+
+    function getter(obj) {
+      if (!obj || typeof obj !== 'object')
+        return '' + obj + '[' + name + ']';
+      return (name in obj) ? obj[name] : 'unknown key: ' + name;
+    }
+  }
+});

--- a/test/metrics.test.js
+++ b/test/metrics.test.js
@@ -9,7 +9,7 @@ xstats.onRecord(function(data) {
   return onRecord && onRecord(data);
 });
 
-describe('xstats', function() {
+describe('express metrics', function() {
   var app, server, request, records;
   beforeEach(function setup(done) {
     records = null;
@@ -90,6 +90,16 @@ describe('xstats', function() {
       if (err) return done(err);
       var now = Date.now();
       expect(records).to.have.property('timestamp').within(now - 300, now);
+      done();
+    });
+  });
+
+  it('adds `version` property', function(done) {
+    var VERSION = require('../package.json').version;
+    app.use(xstats());
+    request.get('/').end(function(err, res) {
+      if (err) return done(err);
+      expect(records).to.have.property('version', VERSION);
       done();
     });
   });


### PR DESCRIPTION
connected to strongloop-internal/scrum-nodeops#422

**Add `record.version` property**

Add a new record property `version` containing the version of
strong-express-metrics that produced the record. This allows consumers
to detect different record formats based on producer's version.

**Fill `record.loopback` for LoopBack applications**

When the metrics middleware is added to a LoopBack application
(or a strong-remoting application), a new top-level property "loopback"
is added to the metrics record. This property contains an object
with the following properties:
- modelName
  The name of the LoopBack model (shared class).
- remoteMethod
  The name of the remote method invoked, e.g. "find" or "prototype.updateAttributes".
- instanceId
  The ID of the target instance (when available).

Examples:

```
POST /api/Cars
  modelName: Car
  remoteMethod: create
  (instanceId not available)

PUT /api/Cars/123
  modelName: Car
  remoteMethod: prototype.updateOrCreate
  instanceId: 123

GET /api/Cars/123
  modelName: Car
  remoteMethod: findById
  instanceId: 123
```

Connect to strongloop/loopback#1276
Requires https://github.com/strongloop/strong-remoting/pull/199

/to @sam-github please review
/to @kraman @altsang please check that  the metadata meets your requirements
/cc @ritch you may want to take a look too
